### PR TITLE
좌표계산기 3단계 - 직선 입력과 출력

### DIFF
--- a/CoordinateCalculator/CoordinateCalculator.xcodeproj/project.pbxproj
+++ b/CoordinateCalculator/CoordinateCalculator.xcodeproj/project.pbxproj
@@ -16,6 +16,8 @@
 		A329AB1C2171ED2A00EDA2C3 /* Shape.swift in Sources */ = {isa = PBXBuildFile; fileRef = A329AB1A2171EBAC00EDA2C3 /* Shape.swift */; };
 		A329AB3221745A8200EDA2C3 /* MyLine.swift in Sources */ = {isa = PBXBuildFile; fileRef = A329AB18217089FE00EDA2C3 /* MyLine.swift */; };
 		A329AB3421745AD900EDA2C3 /* UnitTestShape.swift in Sources */ = {isa = PBXBuildFile; fileRef = A329AB3321745AD900EDA2C3 /* UnitTestShape.swift */; };
+		A329AB352174821E00EDA2C3 /* OutputView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A38F2AF42165E3BF00526BC6 /* OutputView.swift */; };
+		A329AB362174822E00EDA2C3 /* ANSICode.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8377CC6F1F8BAF74007F7335 /* ANSICode.swift */; };
 		A340A210216B3A3900CA37AF /* InputView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A38F2AF62165FADC00526BC6 /* InputView.swift */; };
 		A340A216216B3F3E00CA37AF /* UnitTestTextProcessor.swift in Sources */ = {isa = PBXBuildFile; fileRef = A340A215216B3F3E00CA37AF /* UnitTestTextProcessor.swift */; };
 		A340A217216B3FCD00CA37AF /* MyPoint.swift in Sources */ = {isa = PBXBuildFile; fileRef = A38F2AF82165FB2B00526BC6 /* MyPoint.swift */; };
@@ -229,8 +231,10 @@
 				A329AB3421745AD900EDA2C3 /* UnitTestShape.swift in Sources */,
 				A340A216216B3F3E00CA37AF /* UnitTestTextProcessor.swift in Sources */,
 				A340A210216B3A3900CA37AF /* InputView.swift in Sources */,
+				A329AB362174822E00EDA2C3 /* ANSICode.swift in Sources */,
 				A340A217216B3FCD00CA37AF /* MyPoint.swift in Sources */,
 				A329AB1C2171ED2A00EDA2C3 /* Shape.swift in Sources */,
+				A329AB352174821E00EDA2C3 /* OutputView.swift in Sources */,
 				A3F6E7DC2166F4C4000C927B /* UnitTestTextValidator.swift in Sources */,
 				A329AB3221745A8200EDA2C3 /* MyLine.swift in Sources */,
 				A3F6E7E421675384000C927B /* TextValidator.swift in Sources */,

--- a/CoordinateCalculator/CoordinateCalculator.xcodeproj/project.pbxproj
+++ b/CoordinateCalculator/CoordinateCalculator.xcodeproj/project.pbxproj
@@ -11,6 +11,7 @@
 		8377CC701F8BAF74007F7335 /* ANSICode.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8377CC6F1F8BAF74007F7335 /* ANSICode.swift */; };
 		A329AB162170681400EDA2C3 /* TextProcessor.swift in Sources */ = {isa = PBXBuildFile; fileRef = A329AB152170681400EDA2C3 /* TextProcessor.swift */; };
 		A329AB1721706E5900EDA2C3 /* TextProcessor.swift in Sources */ = {isa = PBXBuildFile; fileRef = A329AB152170681400EDA2C3 /* TextProcessor.swift */; };
+		A329AB19217089FE00EDA2C3 /* MyLine.swift in Sources */ = {isa = PBXBuildFile; fileRef = A329AB18217089FE00EDA2C3 /* MyLine.swift */; };
 		A340A210216B3A3900CA37AF /* InputView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A38F2AF62165FADC00526BC6 /* InputView.swift */; };
 		A340A216216B3F3E00CA37AF /* UnitTestTextProcessor.swift in Sources */ = {isa = PBXBuildFile; fileRef = A340A215216B3F3E00CA37AF /* UnitTestTextProcessor.swift */; };
 		A340A217216B3FCD00CA37AF /* MyPoint.swift in Sources */ = {isa = PBXBuildFile; fileRef = A38F2AF82165FB2B00526BC6 /* MyPoint.swift */; };
@@ -39,6 +40,7 @@
 		8377CC511F8B6F7E007F7335 /* main.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = main.swift; sourceTree = "<group>"; };
 		8377CC6F1F8BAF74007F7335 /* ANSICode.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ANSICode.swift; sourceTree = "<group>"; };
 		A329AB152170681400EDA2C3 /* TextProcessor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TextProcessor.swift; sourceTree = "<group>"; };
+		A329AB18217089FE00EDA2C3 /* MyLine.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MyLine.swift; sourceTree = "<group>"; };
 		A340A215216B3F3E00CA37AF /* UnitTestTextProcessor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UnitTestTextProcessor.swift; sourceTree = "<group>"; };
 		A38F2AF42165E3BF00526BC6 /* OutputView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OutputView.swift; sourceTree = "<group>"; };
 		A38F2AF62165FADC00526BC6 /* InputView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InputView.swift; sourceTree = "<group>"; };
@@ -95,6 +97,7 @@
 				A38F2AF82165FB2B00526BC6 /* MyPoint.swift */,
 				A3F6E7E221675384000C927B /* TextValidator.swift */,
 				A329AB152170681400EDA2C3 /* TextProcessor.swift */,
+				A329AB18217089FE00EDA2C3 /* MyLine.swift */,
 			);
 			path = CoordinateCalculator;
 			sourceTree = "<group>";
@@ -204,6 +207,7 @@
 				A3F6E7E321675384000C927B /* TextValidator.swift in Sources */,
 				8377CC521F8B6F7E007F7335 /* main.swift in Sources */,
 				A38F2AF72165FADC00526BC6 /* InputView.swift in Sources */,
+				A329AB19217089FE00EDA2C3 /* MyLine.swift in Sources */,
 				8377CC701F8BAF74007F7335 /* ANSICode.swift in Sources */,
 				A38F2AF52165E3BF00526BC6 /* OutputView.swift in Sources */,
 			);

--- a/CoordinateCalculator/CoordinateCalculator.xcodeproj/project.pbxproj
+++ b/CoordinateCalculator/CoordinateCalculator.xcodeproj/project.pbxproj
@@ -14,6 +14,8 @@
 		A329AB19217089FE00EDA2C3 /* MyLine.swift in Sources */ = {isa = PBXBuildFile; fileRef = A329AB18217089FE00EDA2C3 /* MyLine.swift */; };
 		A329AB1B2171EBAC00EDA2C3 /* Shape.swift in Sources */ = {isa = PBXBuildFile; fileRef = A329AB1A2171EBAC00EDA2C3 /* Shape.swift */; };
 		A329AB1C2171ED2A00EDA2C3 /* Shape.swift in Sources */ = {isa = PBXBuildFile; fileRef = A329AB1A2171EBAC00EDA2C3 /* Shape.swift */; };
+		A329AB3221745A8200EDA2C3 /* MyLine.swift in Sources */ = {isa = PBXBuildFile; fileRef = A329AB18217089FE00EDA2C3 /* MyLine.swift */; };
+		A329AB3421745AD900EDA2C3 /* UnitTestShape.swift in Sources */ = {isa = PBXBuildFile; fileRef = A329AB3321745AD900EDA2C3 /* UnitTestShape.swift */; };
 		A340A210216B3A3900CA37AF /* InputView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A38F2AF62165FADC00526BC6 /* InputView.swift */; };
 		A340A216216B3F3E00CA37AF /* UnitTestTextProcessor.swift in Sources */ = {isa = PBXBuildFile; fileRef = A340A215216B3F3E00CA37AF /* UnitTestTextProcessor.swift */; };
 		A340A217216B3FCD00CA37AF /* MyPoint.swift in Sources */ = {isa = PBXBuildFile; fileRef = A38F2AF82165FB2B00526BC6 /* MyPoint.swift */; };
@@ -44,6 +46,7 @@
 		A329AB152170681400EDA2C3 /* TextProcessor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TextProcessor.swift; sourceTree = "<group>"; };
 		A329AB18217089FE00EDA2C3 /* MyLine.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MyLine.swift; sourceTree = "<group>"; };
 		A329AB1A2171EBAC00EDA2C3 /* Shape.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Shape.swift; sourceTree = "<group>"; };
+		A329AB3321745AD900EDA2C3 /* UnitTestShape.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UnitTestShape.swift; sourceTree = "<group>"; };
 		A340A215216B3F3E00CA37AF /* UnitTestTextProcessor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UnitTestTextProcessor.swift; sourceTree = "<group>"; };
 		A38F2AF42165E3BF00526BC6 /* OutputView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OutputView.swift; sourceTree = "<group>"; };
 		A38F2AF62165FADC00526BC6 /* InputView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InputView.swift; sourceTree = "<group>"; };
@@ -112,6 +115,7 @@
 				A3F6E7DB2166F4C4000C927B /* UnitTestTextValidator.swift */,
 				A3F6E7DD2166F4C4000C927B /* Info.plist */,
 				A340A215216B3F3E00CA37AF /* UnitTestTextProcessor.swift */,
+				A329AB3321745AD900EDA2C3 /* UnitTestShape.swift */,
 			);
 			path = UnitTestCoordinateCalculator;
 			sourceTree = "<group>";
@@ -222,11 +226,13 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				A329AB3421745AD900EDA2C3 /* UnitTestShape.swift in Sources */,
 				A340A216216B3F3E00CA37AF /* UnitTestTextProcessor.swift in Sources */,
 				A340A210216B3A3900CA37AF /* InputView.swift in Sources */,
 				A340A217216B3FCD00CA37AF /* MyPoint.swift in Sources */,
 				A329AB1C2171ED2A00EDA2C3 /* Shape.swift in Sources */,
 				A3F6E7DC2166F4C4000C927B /* UnitTestTextValidator.swift in Sources */,
+				A329AB3221745A8200EDA2C3 /* MyLine.swift in Sources */,
 				A3F6E7E421675384000C927B /* TextValidator.swift in Sources */,
 				A329AB1721706E5900EDA2C3 /* TextProcessor.swift in Sources */,
 			);

--- a/CoordinateCalculator/CoordinateCalculator.xcodeproj/project.pbxproj
+++ b/CoordinateCalculator/CoordinateCalculator.xcodeproj/project.pbxproj
@@ -12,6 +12,7 @@
 		A329AB162170681400EDA2C3 /* TextProcessor.swift in Sources */ = {isa = PBXBuildFile; fileRef = A329AB152170681400EDA2C3 /* TextProcessor.swift */; };
 		A329AB1721706E5900EDA2C3 /* TextProcessor.swift in Sources */ = {isa = PBXBuildFile; fileRef = A329AB152170681400EDA2C3 /* TextProcessor.swift */; };
 		A329AB19217089FE00EDA2C3 /* MyLine.swift in Sources */ = {isa = PBXBuildFile; fileRef = A329AB18217089FE00EDA2C3 /* MyLine.swift */; };
+		A329AB1B2171EBAC00EDA2C3 /* Shape.swift in Sources */ = {isa = PBXBuildFile; fileRef = A329AB1A2171EBAC00EDA2C3 /* Shape.swift */; };
 		A340A210216B3A3900CA37AF /* InputView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A38F2AF62165FADC00526BC6 /* InputView.swift */; };
 		A340A216216B3F3E00CA37AF /* UnitTestTextProcessor.swift in Sources */ = {isa = PBXBuildFile; fileRef = A340A215216B3F3E00CA37AF /* UnitTestTextProcessor.swift */; };
 		A340A217216B3FCD00CA37AF /* MyPoint.swift in Sources */ = {isa = PBXBuildFile; fileRef = A38F2AF82165FB2B00526BC6 /* MyPoint.swift */; };
@@ -41,6 +42,7 @@
 		8377CC6F1F8BAF74007F7335 /* ANSICode.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ANSICode.swift; sourceTree = "<group>"; };
 		A329AB152170681400EDA2C3 /* TextProcessor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TextProcessor.swift; sourceTree = "<group>"; };
 		A329AB18217089FE00EDA2C3 /* MyLine.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MyLine.swift; sourceTree = "<group>"; };
+		A329AB1A2171EBAC00EDA2C3 /* Shape.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Shape.swift; sourceTree = "<group>"; };
 		A340A215216B3F3E00CA37AF /* UnitTestTextProcessor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UnitTestTextProcessor.swift; sourceTree = "<group>"; };
 		A38F2AF42165E3BF00526BC6 /* OutputView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OutputView.swift; sourceTree = "<group>"; };
 		A38F2AF62165FADC00526BC6 /* InputView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InputView.swift; sourceTree = "<group>"; };
@@ -92,12 +94,13 @@
 			children = (
 				8377CC6F1F8BAF74007F7335 /* ANSICode.swift */,
 				8377CC511F8B6F7E007F7335 /* main.swift */,
-				A38F2AF42165E3BF00526BC6 /* OutputView.swift */,
 				A38F2AF62165FADC00526BC6 /* InputView.swift */,
+				A38F2AF42165E3BF00526BC6 /* OutputView.swift */,
 				A38F2AF82165FB2B00526BC6 /* MyPoint.swift */,
+				A329AB18217089FE00EDA2C3 /* MyLine.swift */,
 				A3F6E7E221675384000C927B /* TextValidator.swift */,
 				A329AB152170681400EDA2C3 /* TextProcessor.swift */,
-				A329AB18217089FE00EDA2C3 /* MyLine.swift */,
+				A329AB1A2171EBAC00EDA2C3 /* Shape.swift */,
 			);
 			path = CoordinateCalculator;
 			sourceTree = "<group>";
@@ -206,6 +209,7 @@
 				A38F2AF92165FB2B00526BC6 /* MyPoint.swift in Sources */,
 				A3F6E7E321675384000C927B /* TextValidator.swift in Sources */,
 				8377CC521F8B6F7E007F7335 /* main.swift in Sources */,
+				A329AB1B2171EBAC00EDA2C3 /* Shape.swift in Sources */,
 				A38F2AF72165FADC00526BC6 /* InputView.swift in Sources */,
 				A329AB19217089FE00EDA2C3 /* MyLine.swift in Sources */,
 				8377CC701F8BAF74007F7335 /* ANSICode.swift in Sources */,

--- a/CoordinateCalculator/CoordinateCalculator.xcodeproj/project.pbxproj
+++ b/CoordinateCalculator/CoordinateCalculator.xcodeproj/project.pbxproj
@@ -13,6 +13,7 @@
 		A329AB1721706E5900EDA2C3 /* TextProcessor.swift in Sources */ = {isa = PBXBuildFile; fileRef = A329AB152170681400EDA2C3 /* TextProcessor.swift */; };
 		A329AB19217089FE00EDA2C3 /* MyLine.swift in Sources */ = {isa = PBXBuildFile; fileRef = A329AB18217089FE00EDA2C3 /* MyLine.swift */; };
 		A329AB1B2171EBAC00EDA2C3 /* Shape.swift in Sources */ = {isa = PBXBuildFile; fileRef = A329AB1A2171EBAC00EDA2C3 /* Shape.swift */; };
+		A329AB1C2171ED2A00EDA2C3 /* Shape.swift in Sources */ = {isa = PBXBuildFile; fileRef = A329AB1A2171EBAC00EDA2C3 /* Shape.swift */; };
 		A340A210216B3A3900CA37AF /* InputView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A38F2AF62165FADC00526BC6 /* InputView.swift */; };
 		A340A216216B3F3E00CA37AF /* UnitTestTextProcessor.swift in Sources */ = {isa = PBXBuildFile; fileRef = A340A215216B3F3E00CA37AF /* UnitTestTextProcessor.swift */; };
 		A340A217216B3FCD00CA37AF /* MyPoint.swift in Sources */ = {isa = PBXBuildFile; fileRef = A38F2AF82165FB2B00526BC6 /* MyPoint.swift */; };
@@ -224,6 +225,7 @@
 				A340A216216B3F3E00CA37AF /* UnitTestTextProcessor.swift in Sources */,
 				A340A210216B3A3900CA37AF /* InputView.swift in Sources */,
 				A340A217216B3FCD00CA37AF /* MyPoint.swift in Sources */,
+				A329AB1C2171ED2A00EDA2C3 /* Shape.swift in Sources */,
 				A3F6E7DC2166F4C4000C927B /* UnitTestTextValidator.swift in Sources */,
 				A3F6E7E421675384000C927B /* TextValidator.swift in Sources */,
 				A329AB1721706E5900EDA2C3 /* TextProcessor.swift in Sources */,

--- a/CoordinateCalculator/CoordinateCalculator/InputView.swift
+++ b/CoordinateCalculator/CoordinateCalculator/InputView.swift
@@ -13,7 +13,7 @@ struct InputView {
     
     static func readInput() -> String {
         print(guideMessage)
-        guard let input:String = readLine() else { return String() }
+        guard let input: String = readLine() else { return String() }
         return input
     }
 }

--- a/CoordinateCalculator/CoordinateCalculator/MyLine.swift
+++ b/CoordinateCalculator/CoordinateCalculator/MyLine.swift
@@ -21,7 +21,9 @@ struct MyLine: CalculableShape {
         return [pointA, pointB]
     }
     
-    var calculationMessage = "두 점 사이의 거리는 "
+    var calculationMessage: String {
+        return "두 점 사이의 거리는 "
+    }
     
     func calculate() -> Double {
         return sqrt(pow(Double(pointA.x-pointB.x), 2) + pow(Double(pointA.y-pointB.y), 2))

--- a/CoordinateCalculator/CoordinateCalculator/MyLine.swift
+++ b/CoordinateCalculator/CoordinateCalculator/MyLine.swift
@@ -1,0 +1,14 @@
+//
+//  MyLine.swift
+//  CoordinateCalculator
+//
+//  Created by 윤지영 on 12/10/2018.
+//  Copyright © 2018 Codesquad Inc. All rights reserved.
+//
+
+import Foundation
+
+struct MyLine {
+    private var pointA = MyPoint(x: 0, y: 0)
+    private var pointB = MyPoint(x: 0, y: 0)
+}

--- a/CoordinateCalculator/CoordinateCalculator/MyLine.swift
+++ b/CoordinateCalculator/CoordinateCalculator/MyLine.swift
@@ -9,6 +9,11 @@
 import Foundation
 
 struct MyLine {
-    private var pointA = MyPoint(x: 0, y: 0)
-    private var pointB = MyPoint(x: 0, y: 0)
+    private(set) var pointA = MyPoint(x: 0, y: 0)
+    private(set) var pointB = MyPoint(x: 0, y: 0)
+    
+    init(pointA:MyPoint, pointB:MyPoint) {
+        self.pointA = pointA
+        self.pointB = pointB
+    }
 }

--- a/CoordinateCalculator/CoordinateCalculator/MyLine.swift
+++ b/CoordinateCalculator/CoordinateCalculator/MyLine.swift
@@ -8,12 +8,22 @@
 
 import Foundation
 
-struct MyLine {
+struct MyLine: CalculableShape {
     private(set) var pointA = MyPoint(x: 0, y: 0)
     private(set) var pointB = MyPoint(x: 0, y: 0)
     
     init(pointA:MyPoint, pointB:MyPoint) {
         self.pointA = pointA
         self.pointB = pointB
+    }
+    
+    var points: [MyPoint] {
+        return [pointA, pointB]
+    }
+    
+    var calculationMessage = "두 점 사이의 거리는 "
+    
+    func calculate() -> Double {
+        return sqrt(pow(Double(pointA.x-pointB.x), 2) + pow(Double(pointA.y-pointB.y), 2))
     }
 }

--- a/CoordinateCalculator/CoordinateCalculator/MyLine.swift
+++ b/CoordinateCalculator/CoordinateCalculator/MyLine.swift
@@ -12,7 +12,7 @@ struct MyLine: CalculableShape {
     private(set) var pointA = MyPoint(x: 0, y: 0)
     private(set) var pointB = MyPoint(x: 0, y: 0)
     
-    init(pointA:MyPoint, pointB:MyPoint) {
+    init(pointA: MyPoint, pointB: MyPoint) {
         self.pointA = pointA
         self.pointB = pointB
     }

--- a/CoordinateCalculator/CoordinateCalculator/MyPoint.swift
+++ b/CoordinateCalculator/CoordinateCalculator/MyPoint.swift
@@ -12,7 +12,7 @@ struct MyPoint: Shape {
     private(set) var x = 0
     private(set) var y = 0
     
-    init(x:Int, y:Int) {
+    init(x: Int, y: Int) {
         self.x = x
         self.y = y
     }

--- a/CoordinateCalculator/CoordinateCalculator/MyPoint.swift
+++ b/CoordinateCalculator/CoordinateCalculator/MyPoint.swift
@@ -8,12 +8,16 @@
 
 import Foundation
 
-struct MyPoint {
+struct MyPoint: Shape {
     private(set) var x = 0
     private(set) var y = 0
     
     init(x:Int, y:Int) {
         self.x = x
         self.y = y
+    }
+    
+    var points: [MyPoint] {
+        return [self]
     }
 }

--- a/CoordinateCalculator/CoordinateCalculator/OutputView.swift
+++ b/CoordinateCalculator/CoordinateCalculator/OutputView.swift
@@ -30,22 +30,18 @@ struct OutputView {
         print("\(shape.calculationMessage)\(shape.calculate())")
     }
     
-    static func drawPoints(_ shape: CalculableShape) {
+    private static func drawPoints(_ shape: Shape) {
         for point in shape.points {
             drawPoint(point)
         }
         moveCursorToEnd()
-        showCalculationResult(of: shape)
+        guard let calculableShape: CalculableShape = shape as? CalculableShape else { return }
+        showCalculationResult(of: calculableShape)
     }
     
     static func drawShape(_ shape: Shape?) {
         guard let shape = shape else { return }
         drawAxis()
-        if (shape.points.count == 1) {
-            drawPoint(shape.points[shape.points.startIndex])
-            moveCursorToEnd()
-            return
-        }
-        drawPoints(shape as! CalculableShape)
+        drawPoints(shape)
     }
 }

--- a/CoordinateCalculator/CoordinateCalculator/OutputView.swift
+++ b/CoordinateCalculator/CoordinateCalculator/OutputView.swift
@@ -22,7 +22,7 @@ struct OutputView {
         print("\(ANSICode.cursor.move(row: originOfY + 1, col: originOfX))")
     }
     
-    static func drawPoint(_ point:MyPoint) {
+    static func drawPoint(_ point: MyPoint) {
         print("\(ANSICode.cursor.move(row: originOfY - point.y, col: originOfX + point.x * 2))\(marker)")
     }
     
@@ -41,7 +41,7 @@ struct OutputView {
     static func drawShape(_ shape: Shape?) {
         guard let shape = shape else { return }
         drawAxis()
-        if (shape.points.count==1) {
+        if (shape.points.count == 1) {
             drawPoint(shape.points[shape.points.startIndex])
             moveCursorToEnd()
             return

--- a/CoordinateCalculator/CoordinateCalculator/OutputView.swift
+++ b/CoordinateCalculator/CoordinateCalculator/OutputView.swift
@@ -44,4 +44,12 @@ struct OutputView {
         drawAxis()
         drawPoints(shape)
     }
+    
+    static func printMessageOfTextInvalidation() {
+        print("\(TextValidation.invalidForm.rawValue) \(TextValidation.outOfRangeInt.rawValue)")
+    }
+    
+    static func printMessage(of coordinatesValidation: TextValidation) {
+        print(coordinatesValidation.rawValue)
+    }
 }

--- a/CoordinateCalculator/CoordinateCalculator/OutputView.swift
+++ b/CoordinateCalculator/CoordinateCalculator/OutputView.swift
@@ -11,6 +11,7 @@ import Foundation
 struct OutputView {
     private static let originOfX = 3
     private static let originOfY = 25
+    private static let distanceMessage = "두 점 사이의 거리는 "
     private static let marker = "🔵"
     
     private static func drawAxis() {
@@ -25,6 +26,19 @@ struct OutputView {
     static func drawPoint(point:MyPoint) {
         drawAxis()
         print("\(ANSICode.cursor.move(row: originOfY - point.y, col: originOfX + point.x * 2))\(marker)")
+        moveCursorToEnd()
+    }
+    
+    private static func calculateDistance(between pointA:MyPoint, and pointB:MyPoint) {
+        let distance = sqrt(pow(Double(pointA.x-pointB.x), 2) + pow(Double(pointA.y-pointB.y), 2))
+        print("\(distanceMessage)\(distance)")
+    }
+    
+    static func drawLine(line:MyLine) {
+        drawAxis()
+        drawPoint(point: line.pointA)
+        drawPoint(point: line.pointB)
+        calculateDistance(between: line.pointA, and: line.pointB)
         moveCursorToEnd()
     }
 }

--- a/CoordinateCalculator/CoordinateCalculator/OutputView.swift
+++ b/CoordinateCalculator/CoordinateCalculator/OutputView.swift
@@ -11,7 +11,6 @@ import Foundation
 struct OutputView {
     private static let originOfX = 3
     private static let originOfY = 25
-    private static let distanceMessage = "두 점 사이의 거리는 "
     private static let marker = "🔵"
     
     private static func drawAxis() {
@@ -23,22 +22,30 @@ struct OutputView {
         print("\(ANSICode.cursor.move(row: originOfY + 1, col: originOfX))")
     }
     
-    static func drawPoint(point:MyPoint) {
-        drawAxis()
+    static func drawPoint(_ point:MyPoint) {
         print("\(ANSICode.cursor.move(row: originOfY - point.y, col: originOfX + point.x * 2))\(marker)")
+    }
+    
+    private static func showCalculationResult(of shape: CalculableShape) {
+        print("\(shape.calculationMessage)\(shape.calculate())")
+    }
+    
+    static func drawPoints(_ shape: CalculableShape) {
+        for point in shape.points {
+            drawPoint(point)
+        }
         moveCursorToEnd()
+        showCalculationResult(of: shape)
     }
     
-    private static func calculateDistance(between pointA:MyPoint, and pointB:MyPoint) {
-        let distance = sqrt(pow(Double(pointA.x-pointB.x), 2) + pow(Double(pointA.y-pointB.y), 2))
-        print("\(distanceMessage)\(distance)")
-    }
-    
-    static func drawLine(line:MyLine) {
+    static func drawShape(_ shape: Shape?) {
+        guard let shape = shape else { return }
         drawAxis()
-        drawPoint(point: line.pointA)
-        drawPoint(point: line.pointB)
-        calculateDistance(between: line.pointA, and: line.pointB)
-        moveCursorToEnd()
+        if (shape.points.count==1) {
+            drawPoint(shape.points[shape.points.startIndex])
+            moveCursorToEnd()
+            return
+        }
+        drawPoints(shape as! CalculableShape)
     }
 }

--- a/CoordinateCalculator/CoordinateCalculator/Shape.swift
+++ b/CoordinateCalculator/CoordinateCalculator/Shape.swift
@@ -1,0 +1,13 @@
+//
+//  Shape.swift
+//  CoordinateCalculator
+//
+//  Created by 윤지영 on 13/10/2018.
+//  Copyright © 2018 Codesquad Inc. All rights reserved.
+//
+
+import Foundation
+
+protocol Shape {
+    var points: [MyPoint] { get }
+}

--- a/CoordinateCalculator/CoordinateCalculator/Shape.swift
+++ b/CoordinateCalculator/CoordinateCalculator/Shape.swift
@@ -20,6 +20,21 @@ protocol CalculableShape: Shape {
 }
 
 struct ShapeGenerator {
+    static func generatePoint(from coordinate: String) -> Point? {
+        let textValidator = TextValidator(text: coordinate)
+        guard textValidator.hasNoInvalidCharacter() else {
+            OutputView.printMessageOfTextInvalidation()
+            return nil
+        }
+        let coordinatesValidation = textValidator.checkTextError()
+        guard coordinatesValidation == .success else {
+            OutputView.printMessage(of: coordinatesValidation)
+            return nil
+        }
+        let point = TextProcessor.extractPoint(from: coordinate)
+        return point
+    }
+    
     static func generateShape(by points: [Point]) -> Shape? {
         switch points.count {
         case 1:

--- a/CoordinateCalculator/CoordinateCalculator/Shape.swift
+++ b/CoordinateCalculator/CoordinateCalculator/Shape.swift
@@ -8,6 +8,26 @@
 
 import Foundation
 
+typealias Point = (x: Int, y: Int)
+
 protocol Shape {
     var points: [MyPoint] { get }
+}
+
+protocol CalculableShape: Shape {
+    var calculationMessage: String { get }
+    func calculate() -> Double
+}
+
+struct ShapeGenerator {
+    static func generateShape(by points: [Point]) -> Shape? {
+        switch points.count {
+        case 1:
+            return MyPoint(x: points[0].x, y: points[0].y)
+        case 2:
+            return MyLine(pointA: MyPoint(x: points[0].x, y: points[0].y), pointB: MyPoint(x: points[1].x, y: points[1].y))
+        default:
+            return nil
+        }
+    }
 }

--- a/CoordinateCalculator/CoordinateCalculator/Shape.swift
+++ b/CoordinateCalculator/CoordinateCalculator/Shape.swift
@@ -8,8 +8,6 @@
 
 import Foundation
 
-typealias Point = (x: Int, y: Int)
-
 protocol Shape {
     var points: [MyPoint] { get }
 }
@@ -20,7 +18,7 @@ protocol CalculableShape: Shape {
 }
 
 struct ShapeGenerator {
-    static func generatePoint(from coordinate: String) -> Point? {
+    static func generatePoint(from coordinate: String) -> MyPoint? {
         let textValidator = TextValidator(text: coordinate)
         guard textValidator.hasNoInvalidCharacter() else {
             OutputView.printMessageOfTextInvalidation()
@@ -32,15 +30,15 @@ struct ShapeGenerator {
             return nil
         }
         let point = TextProcessor.extractPoint(from: coordinate)
-        return point
+        return MyPoint(x: point.x, y: point.y)
     }
     
-    static func generateShape(by points: [Point]) -> Shape? {
+    static func generateShape(by points: [MyPoint]) -> Shape? {
         switch points.count {
         case 1:
-            return MyPoint(x: points[0].x, y: points[0].y)
+            return points[0]
         case 2:
-            return MyLine(pointA: MyPoint(x: points[0].x, y: points[0].y), pointB: MyPoint(x: points[1].x, y: points[1].y))
+            return MyLine(pointA: points[0], pointB: points[1])
         default:
             return nil
         }

--- a/CoordinateCalculator/CoordinateCalculator/TextProcessor.swift
+++ b/CoordinateCalculator/CoordinateCalculator/TextProcessor.swift
@@ -12,6 +12,9 @@ extension String {
     func splitByComma() -> [String] {
         return self.split(separator:",").map({String($0)})
     }
+    func splitByHyphen() -> [String] {
+        return self.split(separator:"-").map({String($0)})
+    }
     func removeBothFirstAndLast() -> String {
         return String(self.dropFirst().dropLast())
     }

--- a/CoordinateCalculator/CoordinateCalculator/TextProcessor.swift
+++ b/CoordinateCalculator/CoordinateCalculator/TextProcessor.swift
@@ -21,10 +21,10 @@ extension String {
 }
 
 struct TextProcessor {
-    static func extractPoint(from coordinate: String) -> Point {
+    static func extractPoint(from coordinate: String) -> MyPoint {
         let xy: [String] = coordinate.removeBothFirstAndLast().splitByComma()
         let x = Int(xy.first ?? "0") ?? 0
         let y = Int(xy.last ?? "0") ?? 0
-        return (x, y)
+        return MyPoint(x: x, y: y)
     }
 }

--- a/CoordinateCalculator/CoordinateCalculator/TextProcessor.swift
+++ b/CoordinateCalculator/CoordinateCalculator/TextProcessor.swift
@@ -21,7 +21,7 @@ extension String {
 }
 
 struct TextProcessor {
-    static func extractXY(from coordinate:String) -> (x:Int, y:Int){
+    static func extractPoint(from coordinate:String) -> Point {
         let xy : [String] = coordinate.removeBothFirstAndLast().splitByComma()
         let x = Int(xy.first ?? "0") ?? 0
         let y = Int(xy.last ?? "0") ?? 0

--- a/CoordinateCalculator/CoordinateCalculator/TextProcessor.swift
+++ b/CoordinateCalculator/CoordinateCalculator/TextProcessor.swift
@@ -10,10 +10,10 @@ import Foundation
 
 extension String {
     func splitByComma() -> [String] {
-        return self.split(separator:",").map({String($0)})
+        return self.split(separator: ",").map({String($0)})
     }
     func splitByHyphen() -> [String] {
-        return self.split(separator:"-").map({String($0)})
+        return self.split(separator: "-").map({String($0)})
     }
     func removeBothFirstAndLast() -> String {
         return String(self.dropFirst().dropLast())
@@ -21,8 +21,8 @@ extension String {
 }
 
 struct TextProcessor {
-    static func extractPoint(from coordinate:String) -> Point {
-        let xy : [String] = coordinate.removeBothFirstAndLast().splitByComma()
+    static func extractPoint(from coordinate: String) -> Point {
+        let xy: [String] = coordinate.removeBothFirstAndLast().splitByComma()
         let x = Int(xy.first ?? "0") ?? 0
         let y = Int(xy.last ?? "0") ?? 0
         return (x, y)

--- a/CoordinateCalculator/CoordinateCalculator/TextValidator.swift
+++ b/CoordinateCalculator/CoordinateCalculator/TextValidator.swift
@@ -8,7 +8,7 @@
 
 import Foundation
 
-public enum TextValidation : String {
+public enum TextValidation: String {
     case success
     case invalidForm = "좌표는 (x,y) 형식으로 입력해주세요."
     case noOneComma = "(x,y) 형식으로 컴마로 x좌표와 y좌표를 구분해주세요."
@@ -17,16 +17,16 @@ public enum TextValidation : String {
 }
 
 struct TextValidator {
-    private let leftBracket : Character = "("
-    private let rightBracket : Character = ")"
-    private let comma : Character = ","
-    private let xyCount : Int = 2
-    private let minNum : Int = 0
-    private let maxNum : Int = 24
+    private let leftBracket: Character = "("
+    private let rightBracket: Character = ")"
+    private let comma: Character = ","
+    private let xyCount: Int = 2
+    private let minNum: Int = 0
+    private let maxNum: Int = 24
     private let validCharacterSet = CharacterSet.init(charactersIn: "0123456789(),")
     private var text = String()
     
-    init(text:String) {
+    init(text: String) {
         self.text = text
     }
     
@@ -42,7 +42,7 @@ struct TextValidator {
     
     private func hasOneComma() -> Bool {
         guard text.contains(comma) else { return false }
-        guard text.firstIndex(of:comma)==text.lastIndex(of:comma) else { return false }
+        guard text.firstIndex(of: comma)==text.lastIndex(of: comma) else { return false }
         return true
     }
     
@@ -52,7 +52,7 @@ struct TextValidator {
         return true
     }
     
-    private func isInRange(num:Int) -> Bool {
+    private func isInRange(num: Int) -> Bool {
         return (minNum <= num && num <= maxNum)
     }
     

--- a/CoordinateCalculator/CoordinateCalculator/TextValidator.swift
+++ b/CoordinateCalculator/CoordinateCalculator/TextValidator.swift
@@ -23,10 +23,15 @@ struct TextValidator {
     private let xyCount : Int = 2
     private let minNum : Int = 0
     private let maxNum : Int = 24
+    private let validCharacterSet = CharacterSet.init(charactersIn: "0123456789(),")
     private var text = String()
     
     init(text:String) {
         self.text = text
+    }
+    
+    func hasNoInvalidCharacter() -> Bool {
+        return (text.rangeOfCharacter(from: validCharacterSet.inverted) == nil)
     }
     
     private func hasBrackets() -> Bool {

--- a/CoordinateCalculator/CoordinateCalculator/TextValidator.swift
+++ b/CoordinateCalculator/CoordinateCalculator/TextValidator.swift
@@ -48,7 +48,7 @@ struct TextValidator {
     }
     
     private func isInRange(num:Int) -> Bool {
-        return ( minNum < num || num < maxNum)
+        return (minNum <= num && num <= maxNum)
     }
     
     private func isIntInRange() -> Bool {

--- a/CoordinateCalculator/CoordinateCalculator/main.swift
+++ b/CoordinateCalculator/CoordinateCalculator/main.swift
@@ -13,11 +13,11 @@ struct CoordinateCalculator {
     
     static func run() {
         let coordinatesInput = InputView.readInput()
-        let coordinates : [String] = coordinatesInput.splitByHyphen()
+        let coordinates: [String] = coordinatesInput.splitByHyphen()
         var points = [Point]()
         
         for coordinate in coordinates {
-            let textValidator = TextValidator(text:coordinate)
+            let textValidator = TextValidator(text: coordinate)
             guard textValidator.hasNoInvalidCharacter() else {
                 print("\(TextValidation.invalidForm.rawValue) \(TextValidation.outOfRangeInt.rawValue)")
                 return

--- a/CoordinateCalculator/CoordinateCalculator/main.swift
+++ b/CoordinateCalculator/CoordinateCalculator/main.swift
@@ -14,10 +14,10 @@ struct CoordinateCalculator {
     static func run() {
         let coordinatesInput = InputView.readInput()
         let coordinates: [String] = coordinatesInput.splitByHyphen()
-        var points = [Point]()
+        var points = [MyPoint]()
         for coordinate in coordinates {
             guard let point = ShapeGenerator.generatePoint(from: coordinate) else { return }
-            points.append((x: point.x, y: point.y))
+            points.append(point)
         }
         let shape = ShapeGenerator.generateShape(by: points)
         OutputView.drawShape(shape)

--- a/CoordinateCalculator/CoordinateCalculator/main.swift
+++ b/CoordinateCalculator/CoordinateCalculator/main.swift
@@ -9,9 +9,16 @@
 import Foundation
 
 struct CoordinateCalculator {
+    static var runAgain = true
+    
     static func run() {
         let coordinate = InputView.readInput()
-        let coordinatesValidation = TextValidator(text:coordinate).checkTextError()
+        let textValidator = TextValidator(text:coordinate)
+        guard textValidator.hasNoInvalidCharacter() else {
+            print("\(TextValidation.invalidForm.rawValue) \(TextValidation.outOfRangeInt.rawValue)")
+            return
+        }
+        let coordinatesValidation = textValidator.checkTextError()
         guard coordinatesValidation == .success else {
             print(coordinatesValidation.rawValue)
             return
@@ -19,7 +26,10 @@ struct CoordinateCalculator {
         let coordinates = TextProcessor.extractXY(from: coordinate)
         let myPoint = MyPoint(x:coordinates.x, y:coordinates.y)
         OutputView.drawPoint(point: myPoint)
+        runAgain = false
     }
 }
 
-CoordinateCalculator.run()
+while(CoordinateCalculator.runAgain) {
+    CoordinateCalculator.run()
+}

--- a/CoordinateCalculator/CoordinateCalculator/main.swift
+++ b/CoordinateCalculator/CoordinateCalculator/main.swift
@@ -15,19 +15,8 @@ struct CoordinateCalculator {
         let coordinatesInput = InputView.readInput()
         let coordinates: [String] = coordinatesInput.splitByHyphen()
         var points = [Point]()
-        
         for coordinate in coordinates {
-            let textValidator = TextValidator(text: coordinate)
-            guard textValidator.hasNoInvalidCharacter() else {
-                print("\(TextValidation.invalidForm.rawValue) \(TextValidation.outOfRangeInt.rawValue)")
-                return
-            }
-            let coordinatesValidation = textValidator.checkTextError()
-            guard coordinatesValidation == .success else {
-                print(coordinatesValidation.rawValue)
-                return
-            }
-            let point = TextProcessor.extractPoint(from: coordinate)
+            guard let point = ShapeGenerator.generatePoint(from: coordinate) else { return }
             points.append((x: point.x, y: point.y))
         }
         let shape = ShapeGenerator.generateShape(by: points)

--- a/CoordinateCalculator/CoordinateCalculator/main.swift
+++ b/CoordinateCalculator/CoordinateCalculator/main.swift
@@ -12,20 +12,24 @@ struct CoordinateCalculator {
     static var runAgain = true
     
     static func run() {
-        let coordinate = InputView.readInput()
-        let textValidator = TextValidator(text:coordinate)
-        guard textValidator.hasNoInvalidCharacter() else {
-            print("\(TextValidation.invalidForm.rawValue) \(TextValidation.outOfRangeInt.rawValue)")
-            return
+        let coordinatesInput = InputView.readInput()
+        let coordinates : [String] = coordinatesInput.splitByHyphen()
+        
+        for coordinate in coordinates {
+            let textValidator = TextValidator(text:coordinate)
+            guard textValidator.hasNoInvalidCharacter() else {
+                print("\(TextValidation.invalidForm.rawValue) \(TextValidation.outOfRangeInt.rawValue)")
+                return
+            }
+            let coordinatesValidation = textValidator.checkTextError()
+            guard coordinatesValidation == .success else {
+                print(coordinatesValidation.rawValue)
+                return
+            }
+            let XY = TextProcessor.extractXY(from: coordinate)
+            let myPoint = MyPoint(x:XY.x, y:XY.y)
+            OutputView.drawPoint(point: myPoint)
         }
-        let coordinatesValidation = textValidator.checkTextError()
-        guard coordinatesValidation == .success else {
-            print(coordinatesValidation.rawValue)
-            return
-        }
-        let coordinates = TextProcessor.extractXY(from: coordinate)
-        let myPoint = MyPoint(x:coordinates.x, y:coordinates.y)
-        OutputView.drawPoint(point: myPoint)
         runAgain = false
     }
 }

--- a/CoordinateCalculator/CoordinateCalculator/main.swift
+++ b/CoordinateCalculator/CoordinateCalculator/main.swift
@@ -14,6 +14,7 @@ struct CoordinateCalculator {
     static func run() {
         let coordinatesInput = InputView.readInput()
         let coordinates : [String] = coordinatesInput.splitByHyphen()
+        var points = [Point]()
         
         for coordinate in coordinates {
             let textValidator = TextValidator(text:coordinate)
@@ -26,10 +27,11 @@ struct CoordinateCalculator {
                 print(coordinatesValidation.rawValue)
                 return
             }
-            let XY = TextProcessor.extractXY(from: coordinate)
-            let myPoint = MyPoint(x:XY.x, y:XY.y)
-            OutputView.drawPoint(point: myPoint)
+            let point = TextProcessor.extractPoint(from: coordinate)
+            points.append((x: point.x, y: point.y))
         }
+        let shape = ShapeGenerator.generateShape(by: points)
+        OutputView.drawShape(shape)
         runAgain = false
     }
 }

--- a/CoordinateCalculator/UnitTestCoordinateCalculator/UnitTestShape.swift
+++ b/CoordinateCalculator/UnitTestCoordinateCalculator/UnitTestShape.swift
@@ -10,10 +10,10 @@ import XCTest
 
 class UnitTestShape: XCTestCase {
     
-    let noPoint = [Point]()
-    let onePoint = [Point(x:1, y:1)]
-    let twoPoints = [Point(x:1, y:1), Point(10,10)]
-    let threePoints = [Point(x:1, y:1), Point(10,10), Point(20,20)]
+    let noPoint = [MyPoint]()
+    let onePoint = [MyPoint(x:1, y:1)]
+    let twoPoints = [MyPoint(x:1, y:1), MyPoint(x:10, y:10)]
+    let threePoints = [MyPoint(x:1, y:1), MyPoint(x:10, y:10), MyPoint(x:20, y:20)]
     
 
     override func setUp() {}

--- a/CoordinateCalculator/UnitTestCoordinateCalculator/UnitTestShape.swift
+++ b/CoordinateCalculator/UnitTestCoordinateCalculator/UnitTestShape.swift
@@ -1,0 +1,37 @@
+//
+//  UnitTestShape.swift
+//  UnitTestInput
+//
+//  Created by 윤지영 on 15/10/2018.
+//  Copyright © 2018 Codesquad Inc. All rights reserved.
+//
+
+import XCTest
+
+class UnitTestShape: XCTestCase {
+    
+    let noPoint = [Point]()
+    let onePoint = [Point(x:1, y:1)]
+    let twoPoints = [Point(x:1, y:1), Point(10,10)]
+    let threePoints = [Point(x:1, y:1), Point(10,10), Point(20,20)]
+    
+
+    override func setUp() {}
+    override func tearDown() {}
+
+    func testShapeGeneratorNil_whenNoPoint() {
+        XCTAssertNil(ShapeGenerator.generateShape(by: noPoint))
+    }
+    
+    func testShapeGeneratorNotNil_whenOnePoint() {
+        XCTAssertNotNil(ShapeGenerator.generateShape(by: onePoint))
+    }
+    
+    func testShapeGeneratorNotNilt_whenTwoPoints() {
+        XCTAssertNotNil(ShapeGenerator.generateShape(by: twoPoints))
+    }
+    
+    func testShapeGeneratorNil_whenThreePoint() {
+        XCTAssertNil(ShapeGenerator.generateShape(by: threePoints))
+    }
+}

--- a/CoordinateCalculator/UnitTestCoordinateCalculator/UnitTestTextProcessor.swift
+++ b/CoordinateCalculator/UnitTestCoordinateCalculator/UnitTestTextProcessor.swift
@@ -26,27 +26,27 @@ class UnitTestTextProcessor: XCTestCase {
     override func tearDown() {}
     
     func test_extractXandY_whenTextIsAllowedForm() {
-        let coordiante = TextProcessor.extractXY(fromCoordinate: coordinateString)
+        let coordiante = TextProcessor.extractXY(from: coordinateString)
         XCTAssertTrue(coordiante.x==coordinateX && coordiante.y==coordinateY)
     }
     
     func test_extractXandY_whenTextHasNoValue() {
-        let coordiante = TextProcessor.extractXY(fromCoordinate: noValue)
+        let coordiante = TextProcessor.extractXY(from: noValue)
         XCTAssertTrue(coordiante.x==defaultCoordinateValue && coordiante.y==defaultCoordinateValue)
     }
     
     func test_extractXandY_whenTextIsIncompleteForm() {
-        let coordiante = TextProcessor.extractXY(fromCoordinate: incompleteValue)
+        let coordiante = TextProcessor.extractXY(from: incompleteValue)
         XCTAssertTrue(coordiante.x==defaultCoordinateValue && coordiante.y==defaultCoordinateValue)
     }
     
     func test_extractXandY_whenTextIsLeftIncompleteForm() {
-        let coordiante = TextProcessor.extractXY(fromCoordinate: leftIncompleteValue)
+        let coordiante = TextProcessor.extractXY(from: leftIncompleteValue)
         XCTAssertTrue(coordiante.x==leftIncompleteCoordinateValue && coordiante.y==leftIncompleteCoordinateValue)
     }
     
     func test_extractXandY_whenTextIsRightIncompleteForm() {
-        let coordiante = TextProcessor.extractXY(fromCoordinate: rightIncompleteValue)
+        let coordiante = TextProcessor.extractXY(from: rightIncompleteValue)
         XCTAssertTrue(coordiante.x==rightIncompleteCoordinateValue && coordiante.y==rightIncompleteCoordinateValue)
     }
 }

--- a/CoordinateCalculator/UnitTestCoordinateCalculator/UnitTestTextProcessor.swift
+++ b/CoordinateCalculator/UnitTestCoordinateCalculator/UnitTestTextProcessor.swift
@@ -26,27 +26,27 @@ class UnitTestTextProcessor: XCTestCase {
     override func tearDown() {}
     
     func test_extractXandY_whenTextIsAllowedForm() {
-        let coordiante = TextProcessor.extractXY(from: coordinateString)
+        let coordiante = TextProcessor.extractPoint(from: coordinateString)
         XCTAssertTrue(coordiante.x==coordinateX && coordiante.y==coordinateY)
     }
     
     func test_extractXandY_whenTextHasNoValue() {
-        let coordiante = TextProcessor.extractXY(from: noValue)
+        let coordiante = TextProcessor.extractPoint(from: noValue)
         XCTAssertTrue(coordiante.x==defaultCoordinateValue && coordiante.y==defaultCoordinateValue)
     }
     
     func test_extractXandY_whenTextIsIncompleteForm() {
-        let coordiante = TextProcessor.extractXY(from: incompleteValue)
+        let coordiante = TextProcessor.extractPoint(from: incompleteValue)
         XCTAssertTrue(coordiante.x==defaultCoordinateValue && coordiante.y==defaultCoordinateValue)
     }
     
     func test_extractXandY_whenTextIsLeftIncompleteForm() {
-        let coordiante = TextProcessor.extractXY(from: leftIncompleteValue)
+        let coordiante = TextProcessor.extractPoint(from: leftIncompleteValue)
         XCTAssertTrue(coordiante.x==leftIncompleteCoordinateValue && coordiante.y==leftIncompleteCoordinateValue)
     }
     
     func test_extractXandY_whenTextIsRightIncompleteForm() {
-        let coordiante = TextProcessor.extractXY(from: rightIncompleteValue)
+        let coordiante = TextProcessor.extractPoint(from: rightIncompleteValue)
         XCTAssertTrue(coordiante.x==rightIncompleteCoordinateValue && coordiante.y==rightIncompleteCoordinateValue)
     }
 }

--- a/CoordinateCalculator/UnitTestCoordinateCalculator/UnitTestTextValidator.swift
+++ b/CoordinateCalculator/UnitTestCoordinateCalculator/UnitTestTextValidator.swift
@@ -20,6 +20,14 @@ class UnitTestTextValidator: XCTestCase {
 
     override func tearDown() {}
     
+    func testInputHasNoInvalidCharacter() {
+        XCTAssertTrue(TextValidator(text:validForm).hasNoInvalidCharacter())
+    }
+    
+    func testInputHasInvalidCharacter() {
+        XCTAssertFalse(TextValidator(text:notInt).hasNoInvalidCharacter())
+    }
+    
     func testInputHasNoError() {
         XCTAssertEqual(TextValidator(text:validForm).checkTextError(), .success)
     }

--- a/CoordinateCalculator/UnitTestCoordinateCalculator/UnitTestTextValidator.swift
+++ b/CoordinateCalculator/UnitTestCoordinateCalculator/UnitTestTextValidator.swift
@@ -17,38 +17,37 @@ class UnitTestTextValidator: XCTestCase {
     let outOfRange = "(29,3)"
 
     override func setUp() {}
-
     override func tearDown() {}
     
     func testInputHasNoInvalidCharacter() {
-        XCTAssertTrue(TextValidator(text:validForm).hasNoInvalidCharacter())
+        XCTAssertTrue(TextValidator(text: validForm).hasNoInvalidCharacter())
     }
     
     func testInputHasInvalidCharacter() {
-        XCTAssertFalse(TextValidator(text:notInt).hasNoInvalidCharacter())
+        XCTAssertFalse(TextValidator(text: notInt).hasNoInvalidCharacter())
     }
     
     func testInputHasNoError() {
-        XCTAssertEqual(TextValidator(text:validForm).checkTextError(), .success)
+        XCTAssertEqual(TextValidator(text: validForm).checkTextError(), .success)
     }
     
     func testInputHasBrackets() {
-        XCTAssertEqual(TextValidator(text:noBracket).checkTextError(), .invalidForm)
+        XCTAssertEqual(TextValidator(text: noBracket).checkTextError(), .invalidForm)
     }
     
     func testInputHasOneComma() {
-        XCTAssertEqual(TextValidator(text:noComma).checkTextError(), .noOneComma)
+        XCTAssertEqual(TextValidator(text: noComma).checkTextError(), .noOneComma)
     }
     
     func testInputHasTwoValues() {
-        XCTAssertEqual(TextValidator.init(text:noTwoValue).checkTextError(), .noBothXY)
+        XCTAssertEqual(TextValidator.init(text: noTwoValue).checkTextError(), .noBothXY)
     }
     
     func testInputIsIntType() {
-        XCTAssertEqual(TextValidator.init(text:notInt).checkTextError(), .outOfRangeInt)
+        XCTAssertEqual(TextValidator.init(text: notInt).checkTextError(), .outOfRangeInt)
     }
     
     func testInputIsNotOutOfRange() {
-        XCTAssertEqual(TextValidator.init(text:outOfRange).checkTextError(), .outOfRangeInt)
+        XCTAssertEqual(TextValidator.init(text: outOfRange).checkTextError(), .outOfRangeInt)
     }
 }

--- a/CoordinateCalculator/UnitTestCoordinateCalculator/UnitTestTextValidator.swift
+++ b/CoordinateCalculator/UnitTestCoordinateCalculator/UnitTestTextValidator.swift
@@ -21,7 +21,7 @@ class UnitTestTextValidator: XCTestCase {
     override func tearDown() {}
     
     func testInputHasNoError() {
-        XCTAssertEqual(TextValidator(text:validForm).checkTextError(), .noError)
+        XCTAssertEqual(TextValidator(text:validForm).checkTextError(), .success)
     }
     
     func testInputHasBrackets() {
@@ -29,11 +29,11 @@ class UnitTestTextValidator: XCTestCase {
     }
     
     func testInputHasOneComma() {
-        XCTAssertEqual(TextValidator(text:noComma).checkTextError(), .invalidForm)
+        XCTAssertEqual(TextValidator(text:noComma).checkTextError(), .noOneComma)
     }
     
     func testInputHasTwoValues() {
-        XCTAssertEqual(TextValidator.init(text:noTwoValue).checkTextError(), .invalidForm)
+        XCTAssertEqual(TextValidator.init(text:noTwoValue).checkTextError(), .noBothXY)
     }
     
     func testInputIsIntType() {


### PR DESCRIPTION
- 두 개의 좌표값을 처리할 수 있도록, 입력받은 값을 `-`로 나누어 따로 선언해놓은 `Point(x:Int, y:Int)` 튜플 타입으로 저장하여 이전 단계에서 수행한 과정을 동일하게 거치도록 만들었습니다.
- `MyLine` 구조체를 추가했습니다. 
- `OutputView` 에서 같은 출력 메소드를 사용하고자 `Shape` 프로토콜을 추가하여 `MyPoint` 와 `MyLine` 이 해당 프로토콜을 따르도록 수정했습니다. 
- `Shape` 에 `[Points]` 라는 내부 프로퍼티를 선언하고, 이를 활용하여 `ShapeGenerator` 를 통해 `OutputView` 에 전달해줄 `MyPoint` 와 `MyLine` 을 생성해주었습니다. 